### PR TITLE
Add extern C declaration for C++ compatibility

### DIFF
--- a/canard_stm32_driver.h
+++ b/canard_stm32_driver.h
@@ -8,8 +8,16 @@
 #ifndef INC_CANARD_STM32_DRIVER_H_
 #define INC_CANARD_STM32_DRIVER_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int16_t canardSTM32Recieve(FDCAN_HandleTypeDef *hfdcan, uint32_t RxLocation, CanardCANFrame *const rx_frame);
 int16_t canardSTM32Transmit(FDCAN_HandleTypeDef *hfdcan, const CanardCANFrame* const tx_frame);
 void getUniqueID(uint8_t id[16]);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INC_CANARD_STM32_DRIVER_H_ */


### PR DESCRIPTION
Currently if you are copying and pasting `canard_stm32_driver.h` into a C++ project the driver fails to link because of C++ name mangling. This fix makes the project compatible with C++ while still maintaining backwards compatibility with C.