### PR TITLE
fix inconsistent function declaration in canard_stm32_driver.h

### DIFF
--- a/canard_stm32_driver.h
+++ b/canard_stm32_driver.h
@@ -12,8 +12,8 @@
 extern "C" {
 #endif
 
-int16_t canardSTM32Recieve(FDCAN_HandleTypeDef *hfdcan, uint32_t RxLocation, CanardCANFrame *const rx_frame);
-int16_t canardSTM32Transmit(FDCAN_HandleTypeDef *hfdcan, const CanardCANFrame* const tx_frame);
+int16_t canardSTM32Recieve(CAN_HandleTypeDef *hcan, uint32_t RxLocation, CanardCANFrame *const rx_frame);
+int16_t canardSTM32Transmit(CAN_HandleTypeDef *hcan, const CanardCANFrame* const tx_frame);
 void getUniqueID(uint8_t id[16]);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Declarations in  canard_stm32_driver.h used FDCAN but definition in canard_stm32_driver.c use regular CAN.
Changed declarations to be consistent with definitions.